### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 [testenv]
 skip_missing_interpreters = True
 usedevelop = True
-commands = py.test --cov=setuptools_odoo --cov-branch --cov-report=html --flake8 --ignore=tests/data {posargs}
+commands = pytest --cov=setuptools_odoo --cov-branch --cov-report=html --flake8 --ignore=tests/data {posargs}
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot