### PR TITLE
Update addons-12c.txt

### DIFF
--- a/setuptools_odoo/addons-12c.txt
+++ b/setuptools_odoo/addons-12c.txt
@@ -41,6 +41,7 @@ crm_project
 crm_reveal
 decimal_precision
 delivery
+delivery_hs_code
 digest
 document
 event


### PR DESCRIPTION
Hi,

I think this module is missing for version 12.0:

https://github.com/odoo/odoo/tree/12.0/addons/delivery_hs_code

Regards,
Kerrim