### PR TITLE
[FIX] Use the '--show-toplevel' param instead of guessing from nothing.

### DIFF
--- a/setuptools_odoo/git_postversion.py
+++ b/setuptools_odoo/git_postversion.py
@@ -42,8 +42,7 @@ def get_git_uncommitted(path):
 
 
 def get_git_root(path):
-    git_dir = _run_git_command_bytes(['rev-parse', '--git-dir'], cwd=path)
-    return os.path.abspath(os.path.join(git_dir, '..'))
+    return _run_git_command_bytes(['rev-parse', '--show-toplevel'], cwd=path)
 
 
 def git_log_iterator(path):


### PR DESCRIPTION
There is a strange case in which the original function does not work.

If you create a script from scratch, import `setuptools_odoo` as a normal Python module and then you call `get_git_postversion` (or simply `get_git_root`) it will be related to the directory in which you run your script.

For example...  
If you run your script from inside your GIT repository, it will work properly (of course)... But...  
If you run your script from outside the GIT repository, it will not work properly.

---

e.g.

```python
# ~/myscript.py

import sys
from setuptools_odoo.git_postversion import get_git_root

print(get_git_root(sys.argv[1]))
```

```bash
# console

~ $ cd /tmp
/tmp $ python3 ~/myscript.py "/home/matteo/myrepo1"

# The output, will be:
/tmp
```
```bash
# console

~ $ cd ~/myrepo1
~/myrepo1 $ python3 ~/myscript.py "/home/matteo/myrepo1"

# The output, will be:
/home/matteo/myrepo1
```
```bash
# console

~ $ cd ~/myrepo1/subdir
~/myrepo1/subdir $ python3 ~/myscript.py "/home/matteo/myrepo1"

# The output, will be:
/home/matteo/myrepo1/subdir
```
```bash
# console

~ $ cd ~/myrepo2
~/myrepo2 $ python3 ~/myscript.py "/home/matteo/myrepo1"

# The output, will be:
/home/matteo/myrepo2
```

---

This PR, fix this behaviour.