### PR TITLE
Support post version strategy override

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Changes
 ------------------
 - [ADD] add new ``.N`` git post version strategy that adds a 6th digit with the
   number of commit since the latest manifest version change
+- [ADD] implement the ``post_version_strategy_override`` keyword that was documented
+  but not effective
+- [ADD] allow overriding the post version strategy using the
+  ``SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE`` environment variable
 - [UPD] update base addons lists
 
 2.6.3 (2021-01-29)

--- a/README.rst
+++ b/README.rst
@@ -419,9 +419,15 @@ N being the number of git commits since the version change.
 These schemes are compliant with the accepted python versioning scheme documented
 in `PEP 440 <https://www.python.org/dev/peps/pep-0440/#developmental-releases>`_.
 
+The default strategy can be overridden using the
+``post_version_strategy_override`` keyword or the
+``SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE`` environment variable. If set
+and not empty, the environment variable has priority over the ``setup.py``
+keyword.
+
 .. Note::
 
-  for pip to install a developmental version, it must be invoked with the --pre
+  For ``pip`` to install a developmental version, it must be invoked with the ``--pre``
   option.
 
 Public API

--- a/setuptools_odoo/core.py
+++ b/setuptools_odoo/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2015-2018 ACSONE SA/NV
+# Copyright © 2015-2021 ACSONE SA/NV
 # License LGPLv3 (http://www.gnu.org/licenses/lgpl-3.0-standalone.html)
 
 import email.parser
@@ -475,6 +475,7 @@ def prepare_odoo_addon(
     depends_override=None,
     external_dependencies_override=None,
     odoo_version_override=None,
+    post_version_strategy_override=None,
 ):
     addons_dir, addons_ns = _find_addons_dir()
     potential_addons = os.listdir(addons_dir)
@@ -510,6 +511,7 @@ def prepare_odoo_addon(
         depends_override,
         external_dependencies_override,
         odoo_version_override,
+        post_version_strategy_override,
     )
 
 

--- a/setuptools_odoo/setup_keywords.py
+++ b/setuptools_odoo/setup_keywords.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2015-2018 ACSONE SA/NV
+# Copyright © 2015-2021 ACSONE SA/NV
 # License LGPLv3 (http://www.gnu.org/licenses/lgpl-3.0-standalone.html)
 
+import os
 import warnings
 
 from .core import prepare_odoo_addon, prepare_odoo_addons
@@ -37,11 +38,22 @@ def _parse_options(value):
     depends_override = {}
     external_dependencies_override = {}
     odoo_version_override = None
+    post_version_strategy_override = None
     if isinstance(value, dict):
         depends_override = value.get("depends_override", {})
         external_dependencies_override = value.get("external_dependencies_override", {})
         odoo_version_override = value.get("odoo_version_override")
-    return (depends_override, external_dependencies_override, odoo_version_override)
+        post_version_strategy_override = value.get("post_version_strategy_override")
+    if os.environ.get("SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE"):
+        post_version_strategy_override = os.environ[
+            "SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE"
+        ]
+    return (
+        depends_override,
+        external_dependencies_override,
+        odoo_version_override,
+        post_version_strategy_override,
+    )
 
 
 def odoo_addon(dist, attr, value):
@@ -49,11 +61,13 @@ def odoo_addon(dist, attr, value):
         depends_override,
         external_dependencies_override,
         odoo_version_override,
+        post_version_strategy_override,
     ) = _parse_options(value)
     setup_keywords = prepare_odoo_addon(
         depends_override=depends_override,
         external_dependencies_override=external_dependencies_override,
         odoo_version_override=odoo_version_override,
+        post_version_strategy_override=post_version_strategy_override,
     )
     _set_dist_keywords(dist, setup_keywords)
 
@@ -63,6 +77,7 @@ def odoo_addons(dist, attr, value):
         depends_override,
         external_dependencies_override,
         odoo_version_override,
+        _,
     ) = _parse_options(value)
     setup_keywords = prepare_odoo_addons(
         depends_override=depends_override,

--- a/tests/test_setup_keywords.py
+++ b/tests/test_setup_keywords.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright © 2015-2018 ACSONE SA/NV
+# Copyright © 2015-2021 ACSONE SA/NV
 # License LGPLv3 (http://www.gnu.org/licenses/lgpl-3.0-standalone.html)
 
 import glob
@@ -34,6 +34,23 @@ class TestSetupKeywords(unittest.TestCase):
             )
             self.assertTrue(dist.has_metadata("not-zip-safe"))
             self.assertEqual(dist.version, "8.0.1.0.0.99.dev4")
+        finally:
+            shutil.rmtree(egg_info_dir)
+
+    def test_odoo_addon1_post_version_override_env(self):
+        """Test post version strategy override via environment variable."""
+        addon1_dir = os.path.join(DATA_DIR, "setup_reusable_addons", "addon1")
+        subprocess.check_call(
+            [sys.executable, "setup.py", "egg_info"],
+            cwd=addon1_dir,
+            env=dict(os.environ, SETUPTOOLS_ODOO_POST_VERSION_STRATEGY_OVERRIDE="none"),
+        )
+        egg_info_dir = os.path.join(addon1_dir, "odoo8_addon_addon1.egg-info")
+        assert os.path.isdir(egg_info_dir)
+        try:
+            dist = next(pkg_resources.find_distributions(addon1_dir))
+            self.assertEqual(dist.key, "odoo8-addon-addon1")
+            self.assertEqual(dist.version, "8.0.1.0.0")
         finally:
             shutil.rmtree(egg_info_dir)
 


### PR DESCRIPTION
In some contexts, users are not interested in the post version strategy.

For instance, this can speed-up CI install operations in repos with a large number of addons.