### PR TITLE
The metadata we generate is 2.2 compliant

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changes
 .. ----------
 .. -
 
+3.0.0 (unreleased)
+------------------
+- Generate Metada-Version 2.2. Since metadata obtained from a sdist with PKG-INFO
+  is directly read from the PKG-INFO, all metadata is static by definition.
+
 2.7.1 (2021-03-15)
 ------------------
 - ``setuptools-odoo-get-requirements --include-addons`` does not output

--- a/setuptools_odoo/core.py
+++ b/setuptools_odoo/core.py
@@ -402,7 +402,7 @@ def get_addon_metadata(
             for item in svalue:
                 meta[name] = item
 
-    meta["Metadata-Version"] = "2.1"
+    meta["Metadata-Version"] = "2.2"
     _set("Name", "name")
     _set("Version", "version")
     _set("Requires-Python", "python_requires")

--- a/tests/test_get_addon_metadata.py
+++ b/tests/test_get_addon_metadata.py
@@ -27,7 +27,7 @@ def test_addon1():
     _assert_msg(
         metadata,
         [
-            ("Metadata-Version", "2.1"),
+            ("Metadata-Version", "2.2"),
             ("Name", "odoo8-addon-addon1"),
             ("Version", "8.0.1.0.0.99.dev4"),
             ("Requires-Python", "~=2.7"),


### PR DESCRIPTION
Because all metadata is static (from __manifest__.py and/or setup.py),
except the version which may be influenced by the VCS.
But when building from a sdist, we use PKG-INFO
to find the version so it is static too.

https://packaging.python.org/specifications/core-metadata/#dynamic-multiple-use