### PR TITLE
Support new naming scheme in metapackage too

### DIFF
--- a/setuptools_odoo/core.py
+++ b/setuptools_odoo/core.py
@@ -28,7 +28,7 @@ ODOO_VERSION_INFO = {
     "7.0": {
         "odoo_dep": "openerp>=7.0a,<8.0a",
         "base_addons": base_addons.openerp7,
-        "pkg_name_pfx": "openerp7-addon-",
+        "pkg_name_pfx": "openerp7-addon",
         "addons_ns": "openerp_addons",
         "namespace_packages": ["openerp_addons"],
         "python_requires": "~=2.7",
@@ -38,7 +38,7 @@ ODOO_VERSION_INFO = {
     "8.0": {
         "odoo_dep": "odoo>=8.0a,<9.0a",
         "base_addons": base_addons.odoo8,
-        "pkg_name_pfx": "odoo8-addon-",
+        "pkg_name_pfx": "odoo8-addon",
         "addons_ns": "odoo_addons",
         "namespace_packages": ["odoo_addons"],
         "python_requires": "~=2.7",
@@ -48,7 +48,7 @@ ODOO_VERSION_INFO = {
     "9.0": {
         "odoo_dep": "odoo>=9.0a,<9.1a",
         "base_addons": base_addons.odoo9,
-        "pkg_name_pfx": "odoo9-addon-",
+        "pkg_name_pfx": "odoo9-addon",
         "addons_ns": "odoo_addons",
         "namespace_packages": ["odoo_addons"],
         "python_requires": "~=2.7",
@@ -58,7 +58,7 @@ ODOO_VERSION_INFO = {
     "10.0": {
         "odoo_dep": "odoo>=10.0,<10.1dev",
         "base_addons": base_addons.odoo10,
-        "pkg_name_pfx": "odoo10-addon-",
+        "pkg_name_pfx": "odoo10-addon",
         "addons_ns": "odoo.addons",
         "namespace_packages": ["odoo", "odoo.addons"],
         "python_requires": "~=2.7",
@@ -68,7 +68,7 @@ ODOO_VERSION_INFO = {
     "11.0": {
         "odoo_dep": "odoo>=11.0a,<11.1dev",
         "base_addons": base_addons.odoo11,
-        "pkg_name_pfx": "odoo11-addon-",
+        "pkg_name_pfx": "odoo11-addon",
         "addons_ns": "odoo.addons",
         "namespace_packages": None,
         "python_requires": ", ".join(
@@ -80,7 +80,7 @@ ODOO_VERSION_INFO = {
     "12.0": {
         "odoo_dep": "odoo>=12.0a,<12.1dev",
         "base_addons": base_addons.odoo12,
-        "pkg_name_pfx": "odoo12-addon-",
+        "pkg_name_pfx": "odoo12-addon",
         "addons_ns": "odoo.addons",
         "namespace_packages": None,
         "python_requires": ">=3.5",
@@ -90,7 +90,7 @@ ODOO_VERSION_INFO = {
     "13.0": {
         "odoo_dep": "odoo>=13.0a,<13.1dev",
         "base_addons": base_addons.odoo13,
-        "pkg_name_pfx": "odoo13-addon-",
+        "pkg_name_pfx": "odoo13-addon",
         "addons_ns": "odoo.addons",
         "namespace_packages": None,
         "python_requires": ">=3.5",
@@ -100,7 +100,7 @@ ODOO_VERSION_INFO = {
     "14.0": {
         "odoo_dep": "odoo>=14.0a,<14.1dev",
         "base_addons": base_addons.odoo14,
-        "pkg_name_pfx": "odoo14-addon-",
+        "pkg_name_pfx": "odoo14-addon",
         "addons_ns": "odoo.addons",
         "namespace_packages": None,
         "python_requires": ">=3.6",
@@ -110,7 +110,7 @@ ODOO_VERSION_INFO = {
     "15.0": {
         "odoo_dep": "odoo>=15.0a,<15.1dev",
         "base_addons": base_addons.odoo15,
-        "pkg_name_pfx": "odoo-addon-",
+        "pkg_name_pfx": "odoo-addon",
         "pkg_version_specifier": ">=15.0dev,<15.1dev",
         "addons_ns": "odoo.addons",
         "namespace_packages": None,
@@ -212,7 +212,7 @@ def _get_author_email(manifest):
 
 
 def make_pkg_name(odoo_version_info, addon_name):
-    name = odoo_version_info["pkg_name_pfx"] + addon_name
+    name = odoo_version_info["pkg_name_pfx"] + "-" + addon_name
     return name
 
 

--- a/setuptools_odoo/make_default_setup.py
+++ b/setuptools_odoo/make_default_setup.py
@@ -30,7 +30,7 @@ with open('VERSION.txt', 'r') as f:
     version = f.read().strip()
 
 setuptools.setup(
-    name="odoo{odoo_series}-addons-{name}",
+    name="{pkg_name_pfx}s-{name}",
     description="Meta package for {name} Odoo addons",
     version=version,
     install_requires={install_requires},
@@ -190,7 +190,6 @@ def make_default_meta_package(addons_dir, name, odoo_version_override):
         )
 
     odoo_version = list(odoo_versions)[0]
-    odoo_series = _odoo_version_to_series(odoo_version)
 
     install_requires_str = "[\n{}{}]".format(
         "".join(
@@ -205,7 +204,7 @@ def make_default_meta_package(addons_dir, name, odoo_version_override):
     setup_py = SETUP_PY_METAPACKAGE.format(
         name=name,
         odoo_version=odoo_version,
-        odoo_series=odoo_series,
+        pkg_name_pfx=odoo_version_info["pkg_name_pfx"],
         install_requires=install_requires_str,
     )
 

--- a/tests/test_make_default_setup.py
+++ b/tests/test_make_default_setup.py
@@ -11,6 +11,8 @@ import tempfile
 import textwrap
 import unittest
 
+import pytest
+
 from setuptools_odoo import make_default_setup
 
 from . import DATA_DIR
@@ -90,76 +92,88 @@ class TestMakeDefaultSetup(unittest.TestCase):
             shutil.rmtree(tmpdir)
 
 
-def test_make_default_setup_metapackage():
-    tmpdir = tempfile.mkdtemp()
-    source_addons_path = os.path.join(
-        os.getcwd(), "tests", "data", "setup_custom_project", "odoo_addons"
-    )
-    addons_path = os.path.join(tmpdir, "tests")
-    metapackage_dir = os.path.join(addons_path, "setup", "_metapackage")
-    setup_file = os.path.join(metapackage_dir, "setup.py")
-    version_file = os.path.join(metapackage_dir, "VERSION.txt")
+@pytest.mark.parametrize(
+    ("series", "pkg_name_pfx", "pkg_version_specifier"),
+    [
+        ("8", "odoo8-addon", ""),
+        ("15", "odoo-addon", ">=15.0dev,<15.1dev"),
+    ],
+)
+def test_make_default_setup_metapackage(
+    series, pkg_name_pfx, pkg_version_specifier, tmp_path
+):
+    addons_path = tmp_path / "tests"
+    addons_path.mkdir()
+    metapackage_dir = addons_path / "setup" / "_metapackage"
+    setup_file = metapackage_dir / "setup.py"
+    version_file = metapackage_dir / "VERSION.txt"
     today_date = datetime.date.today().strftime("%Y%m%d")
     expected_setup_file = textwrap.dedent(
         """\
-        import setuptools
+            import setuptools
 
-        with open('VERSION.txt', 'r') as f:
-            version = f.read().strip()
+            with open('VERSION.txt', 'r') as f:
+                version = f.read().strip()
 
-        setuptools.setup(
-            name="odoo8-addons-tests",
-            description="Meta package for tests Odoo addons",
-            version=version,
-            install_requires=[
-                'odoo8-addon-addon1',
-            ],
-            classifiers=[
-                'Programming Language :: Python',
-                'Framework :: Odoo',
-                'Framework :: Odoo :: 8.0',
-            ]
+            setuptools.setup(
+                name="{pkg_name_pfx}s-tests",
+                description="Meta package for tests Odoo addons",
+                version=version,
+                install_requires=[
+                    '{pkg_name_pfx}-addon1{pkg_version_specifier}',
+                ],
+                classifiers=[
+                    'Programming Language :: Python',
+                    'Framework :: Odoo',
+                    'Framework :: Odoo :: {series}.0',
+                ]
+            )
+        """.format(
+            series=series,
+            pkg_name_pfx=pkg_name_pfx,
+            pkg_version_specifier=pkg_version_specifier,
         )
-    """
     )
 
-    try:
-        shutil.copytree(source_addons_path, addons_path)
-        make_default_setup.make_default_setup_addons_dir(addons_path, False, False)
-        with open(
-            os.path.join(addons_path, "setup", ".setuptools-odoo-make-default-ignore"),
-            "a",
-        ) as f:
-            f.write("addon2\n")
-        make_default_setup.make_default_meta_package(
-            addons_path, "tests", odoo_version_override=None
-        )
+    addon1_path = addons_path / "addon1"
+    addon1_path.mkdir()
+    (addon1_path / "__manifest__.py").write_text(
+        u"{{'version': '{series}.0.1.0.0'}}".format(series=series)
+    )
+    addon2_path = addons_path / "addon2"
+    addon2_path.mkdir()
+    (addon2_path / "__manifest__.py").write_text(
+        u"{{'version': '{series}.0.1.0.0'}}".format(series=series)
+    )
+    make_default_setup.make_default_setup_addons_dir(str(addons_path), False, False)
+    (addons_path / "setup" / ".setuptools-odoo-make-default-ignore").write_text(
+        u"addon2\n"
+    )
+    make_default_setup.make_default_meta_package(
+        str(addons_path), "tests", odoo_version_override=None
+    )
 
-        with open(setup_file, "r") as f:
-            setup_file_content = f.read()
-            assert setup_file_content == expected_setup_file
+    assert setup_file.read_text() == expected_setup_file
 
-        with open(version_file, "r") as f:
-            version = f.read().strip()
-            assert version == "8.0.%s.0" % today_date
+    assert version_file.read_text() == "{series}.0.{today_date}.0".format(
+        series=series, today_date=today_date
+    )
 
-        # Create a new addon
-        addon1_path = os.path.join(addons_path, "addon1")
-        new_addon_path = os.path.join(addons_path, "addon99")
-        shutil.copytree(addon1_path, new_addon_path)
+    # Create a new addon
+    new_addon_path = addons_path / "addon99"
+    new_addon_path.mkdir()
+    (new_addon_path / "__manifest__.py").write_text(
+        u"{{'version': '{series}.0.1.0.0'}}".format(series=series)
+    )
 
-        make_default_setup.make_default_setup_addons_dir(addons_path, False, False)
-        make_default_setup.make_default_meta_package(
-            addons_path, "tests", odoo_version_override=None
-        )
+    make_default_setup.make_default_setup_addons_dir(str(addons_path), False, False)
+    make_default_setup.make_default_meta_package(
+        str(addons_path), "tests", odoo_version_override=None
+    )
 
-        with open(version_file, "r") as f:
-            version = f.read().strip()
-            assert (
-                version == "8.0.%s.1" % today_date
-            ), "The version should have been incremented"
-    finally:
-        shutil.rmtree(tmpdir)
+    assert version_file.read_text() == "{series}.0.{today_date}.1".format(
+        series=series, today_date=today_date
+    ), "The version should have been incremented"
 
 
 def test_make_default_setup_commit(tmpdir):


### PR DESCRIPTION
`setuptools-odoo-make-default --metapackage` must use the new naming scheme too.