### PR TITLE
Odoo 15 minimum support python version is 3.7

### DIFF
--- a/newsfragments/66.feature
+++ b/newsfragments/66.feature
@@ -1,0 +1,1 @@
+Odoo 15 addons now require python >= 3.7 by default.

--- a/setuptools_odoo/core.py
+++ b/setuptools_odoo/core.py
@@ -114,7 +114,7 @@ ODOO_VERSION_INFO = {
         "pkg_version_specifier": ">=15.0dev,<15.1dev",
         "addons_ns": "odoo.addons",
         "namespace_packages": None,
-        "python_requires": ">=3.8",
+        "python_requires": ">=3.7",
         "universal_wheel": False,
         "git_postversion_strategy": STRATEGY_DOT_N,
     },

--- a/tests/test_get_addon_metadata.py
+++ b/tests/test_get_addon_metadata.py
@@ -59,7 +59,7 @@ def test_addon9():
             ("Metadata-Version", "2.2"),
             ("Name", "odoo-addon-addon9"),
             ("Version", "15.0.1.0.0"),
-            ("Requires-Python", ">=3.8"),
+            ("Requires-Python", ">=3.7"),
             ("Requires-Dist", "odoo-addon-another_addon>=15.0dev,<15.1dev"),
             ("Requires-Dist", "odoo>=15.0a,<15.1dev"),
             ("Summary", "Addon 9"),


### PR DESCRIPTION
Odoo's minimum supported python version is 3.7. So let's align with this.

https://github.com/odoo/odoo/commit/794677fb6a3391379200eb2144a6ed372e89c17a