### PR TITLE
Require python 3.10 by default for Odoo 16

### DIFF
--- a/newsfragments/93.feature
+++ b/newsfragments/93.feature
@@ -1,0 +1,1 @@
+Require python 3.10 for Odoo 16.

--- a/setuptools_odoo/core.py
+++ b/setuptools_odoo/core.py
@@ -125,7 +125,7 @@ ODOO_VERSION_INFO = {
         "pkg_version_specifier": ">=16.0dev,<16.1dev",
         "addons_ns": "odoo.addons",
         "namespace_packages": None,
-        "python_requires": ">=3.8",
+        "python_requires": ">=3.10",
         "universal_wheel": False,
         "git_postversion_strategy": STRATEGY_DOT_N,
     },


### PR DESCRIPTION
Because Odoo's runbot tests with Python 3.10