### PR TITLE
Generate python metadata 2.1

### DIFF
--- a/newsfragments/112.feature
+++ b/newsfragments/112.feature
@@ -1,0 +1,3 @@
+Generate python metadata version 2.1 instead 2.2. We are compatible with 2.1, and while
+PyPI does not support 2.2 packages generated with such metadata can't be uploaded to
+PyPI.

--- a/setuptools_odoo/core.py
+++ b/setuptools_odoo/core.py
@@ -477,7 +477,7 @@ def get_addon_metadata(
             for item in svalue:
                 meta[name] = item
 
-    meta["Metadata-Version"] = "2.2"
+    meta["Metadata-Version"] = "2.1"
     _set("Name", "name")
     _set("Version", "version")
     _set("Requires-Python", "python_requires")

--- a/tests/test_get_addon_metadata.py
+++ b/tests/test_get_addon_metadata.py
@@ -28,7 +28,7 @@ def test_addon1():
     _assert_msg(
         metadata,
         [
-            ("Metadata-Version", "2.2"),
+            ("Metadata-Version", "2.1"),
             ("Name", "odoo8-addon-addon1"),
             ("Version", "8.0.1.0.0.99.dev4"),
             ("Requires-Python", "~=2.7"),
@@ -56,7 +56,7 @@ def test_addon9():
     _assert_msg(
         metadata,
         [
-            ("Metadata-Version", "2.2"),
+            ("Metadata-Version", "2.1"),
             ("Name", "odoo-addon-addon9"),
             ("Version", "15.0.1.0.0"),
             ("Requires-Python", ">=3.8"),


### PR DESCRIPTION
We are compatible with 2.1, and while PyPI does not support 2.2 it's useless.