### PR TITLE
Improve setuptools-odoo-makedefault compatibility witn Windows

### DIFF
--- a/110.bugfix
+++ b/110.bugfix
@@ -1,0 +1,1 @@
+Improve setuptools-odoo-make-default Windows compatibility.

--- a/setuptools_odoo/make_default_setup.py
+++ b/setuptools_odoo/make_default_setup.py
@@ -6,6 +6,7 @@ import argparse
 import datetime
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -318,9 +319,11 @@ def clean_setup_addons_dir(addons_dir, odoo_version_override):
         paths_to_remove.append(metapackage_dir)
 
     # XXX we may want to clean metapackage_dir/setup.cfg if not universal_wheel
-
-    paths_to_remove = [os.path.abspath(p) for p in paths_to_remove]
-    subprocess.check_call(["rm", "-rf"] + paths_to_remove)
+    for p in paths_to_remove:
+        if os.path.isdir(p):
+            shutil.rmtree(p)
+        else:
+            os.unlink(p)
 
 
 def check_setup_dir_is_git_clean(addons_dir):


### PR DESCRIPTION
Don't use rm -f.

closes #110 
supersedes #111