### PR TITLE
Pin setuptools<82

### DIFF
--- a/newsfragments/125.feature
+++ b/newsfragments/125.feature
@@ -1,0 +1,1 @@
+Pin setuptools<82 in order to have ``pkg_resources`` which was removed in setuptools 82.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     url="http://github.com/acsone/setuptools-odoo",
     packages=["setuptools_odoo"],
     include_package_data=True,
-    install_requires=["setuptools", "setuptools_scm>=2.1,!=4.0.0"],
+    install_requires=["setuptools<82", "setuptools_scm>=2.1,!=4.0.0"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     setup_requires=["setuptools-scm!=4.0.0"],
     test_suite="tests",


### PR DESCRIPTION
We need pkg_resources for now, and setuptools 82 has removed it.